### PR TITLE
Generate code from AST

### DIFF
--- a/logfix/__init__.py
+++ b/logfix/__init__.py
@@ -165,15 +165,20 @@ def get_patch(source: str, path: str) -> dict:
                 format_string = ""
                 for v in arg.values:
                     if isinstance(v, ast.FormattedValue):
-                        # args.append(ast.unparse(v.value))
+                        # The value will consist of a variable name or constant
+                        # and possibly a format specifier
                         if isinstance(v, ast.Name):
                             args.append(v.id)
-                        else:
+                        elif isinstance(v, ast.Constant):
                             args.append(v.value)
+                        else:
+                            skip(path, node)
+                            continue
                         format_string += get_format_spec(v)
                     elif isinstance(v, ast.Constant):
                         format_string += v.value
                     else:
+                        # TODO: Should skip() here?
                         raise Exception(f"Unknown value: {v} type: {type(v)}")
                 node.args.append(ast.Constant(format_string))
                 node.args.extend(args)

--- a/logfix/__init__.py
+++ b/logfix/__init__.py
@@ -126,7 +126,7 @@ def get_patch(source: str, path: str) -> dict:
             if is_str_format(arg):
                 if isinstance(arg.func.value, ast.Constant) and len(arg.keywords) == 0:
                     # We only handle cases where the LHS is a literal string
-                    # constant with no keywork substitutions.
+                    # constant with no keyword substitutions.
                     format_string = re.sub(
                         r"{\s*}",
                         "%s",
@@ -139,16 +139,11 @@ def get_patch(source: str, path: str) -> dict:
                         node.args = list()
                         node.args.append(ast.Constant(format_string))
                         node.args.extend(arg.args)
-                        # quote = '"'
-                        # if quote in format_string:
-                        #     quote = "'"
-                        # args = ", ".join([ast.unparse(a) for a in arg.args])
                         patch = Patch(
                             node.lineno,
                             node.end_lineno,
                             node.col_offset,
                             ast.unparse(node)
-                            #f"{method_call}({quote}{format_string}{quote}, {args})",
                         )
                         patches[patch.line] = patch
                 else:
@@ -157,27 +152,11 @@ def get_patch(source: str, path: str) -> dict:
                 node.args = list()
                 node.args.append(arg.left)
                 if isinstance(arg.right, ast.Tuple):
-                    # args = ", ".join([ast.unparse(item) for item in arg.right.elts])
                     node.args.extend(arg.right.elts)
                 else:
-                    # args = ast.unparse(arg.right)
                     node.args.append(arg.right)
-                # if isinstance(arg.left, ast.Name):
-                #     value = arg.left.id
-                # elif isinstance(arg.left, ast.Constant):
-                #     if '"' in arg.left.value:
-                #         value = f"'{arg.left.value}'"
-                #     else:
-                #         value = f'"{arg.left.value}"'
-                # else:
-                #     skip(path, node)
-                #     continue
                 patch = Patch(
-                    node.lineno,
-                    node.end_lineno,
-                    node.col_offset,
-                    ast.unparse(node)
-                    #f"{method_call}({value}, {args})",
+                    node.lineno, node.end_lineno, node.col_offset, ast.unparse(node)
                 )
                 patches[patch.line] = patch
             elif isinstance(arg, ast.JoinedStr):
@@ -198,24 +177,9 @@ def get_patch(source: str, path: str) -> dict:
                         raise Exception(f"Unknown value: {v} type: {type(v)}")
                 node.args.append(ast.Constant(format_string))
                 node.args.extend(args)
-                # quote = '"'
-                # if quote in format_string:
-                #     quote = "'"
-                # if len(args) == 0:
-                #     patch = Patch(
-                #         node.lineno,
-                #         node.end_lineno,
-                #         node.col_offset,
-                #         f"{method_call}({quote}{format_string}{quote})",
-                #     )
-                # else:
-                #     patch = Patch(
-                #         node.lineno,
-                #         node.end_lineno,
-                #         node.col_offset,
-                #         f"{method_call}({quote}{format_string}{quote}, {', '.join(args)})",
-                #     )
-                patch = Patch(node.lineno, node.end_lineno, node.col_offset, ast.unparse(node))
+                patch = Patch(
+                    node.lineno, node.end_lineno, node.col_offset, ast.unparse(node)
+                )
                 patches[patch.line] = patch
     return patches
 

--- a/logfix/main.py
+++ b/logfix/main.py
@@ -13,7 +13,6 @@ def run(directory: str):
         for file in files:
             if file.endswith(".py"):
                 files_checked += 1
-                print(f"{files_checked:04} {file}")
                 n = patch_file(f"{root}/{file}")
                 if n > 0:
                     files_patched += 1

--- a/test/patch_tests.py
+++ b/test/patch_tests.py
@@ -12,7 +12,7 @@ class PatchTestBase(unittest.TestCase):
         assert 1 == len(patches)
         assert 1 in patches
         actual = patches[1].render()
-        assert actual == expected, f"{actual} != {expected}"
+        assert actual == expected, f'{actual} != {expected}'
 
     def assert_unchanged(self, source):
         patches = get_patch(source, "__fake__.py")
@@ -48,33 +48,33 @@ class MethodTests(PatchTestBase):
 
 class ModOpTests(PatchTestBase):
     def test_modop(self):
-        source = 'log.debug("%s" % a)'
-        expected = 'log.debug("%s", a)'
+        source = "log.debug('%s' % a)"
+        expected = "log.debug('%s', a)"
         self.assert_patched(source, expected)
 
     def test_modop_3(self):
-        source = 'log.debug("%s %s %s" % (a, b, c))'
-        expected = 'log.debug("%s %s %s", a, b, c)'
+        source = "log.debug('%s %s %s' % (a, b, c))"
+        expected = "log.debug('%s %s %s', a, b, c)"
         self.assert_patched(source, expected)
 
     def test_modop_3_functions(self):
-        source = 'log.debug("%d %f %s" % (a+b, log(a), foo(bar(x,y))))'
-        expected = 'log.debug("%d %f %s", a + b, log(a), foo(bar(x, y)))'
+        source = "log.debug('%d %f %s' % (a+b, log(a), foo(bar(x,y))))"
+        expected = "log.debug('%d %f %s', a + b, log(a), foo(bar(x, y)))"
         self.assert_patched(source, expected)
 
     def test_modop_from_tasks_py(self):
-        source = 'log.debug("_cancel_job for job %d: Stopping running task %d" % (job.id, task.id))'
-        expected = 'log.debug("_cancel_job for job %d: Stopping running task %d", job.id, task.id)'
+        source = "log.debug('_cancel_job for job %d: Stopping running task %d' % (job.id, task.id))"
+        expected = "log.debug('_cancel_job for job %d: Stopping running task %d', job.id, task.id)"
         self.assert_patched(source, expected)
 
     def test_modof_value_formats(self):
-        source = 'log.debug("%2.3f %03d %-20s" % (3.14, 1, "hello"))'
-        expected = "log.debug(\"%2.3f %03d %-20s\", 3.14, 1, 'hello')"
+        source = "log.debug('%2.3f %03d %-20s' % (3.14, 1, 'hello'))"
+        expected = "log.debug('%2.3f %03d %-20s', 3.14, 1, 'hello')"
         self.assert_patched(source, expected)
 
     def test_preserve_format_string_modop_3(self):
-        source = 'log.info("%s %d %f" % (a, b, c))'
-        expected = 'log.info("%s %d %f", a, b, c)'
+        source = "log.info('%s %d %f' % (a, b, c))"
+        expected = "log.info('%s %d %f', a, b, c)"
         self.assert_patched(source, expected)
 
     def test_mod_op_2_named_parameters(self):
@@ -85,62 +85,64 @@ class ModOpTests(PatchTestBase):
 
 class PatchFStringTest(PatchTestBase):
     def test_fstring(self):
-        source = 'log.debug(f"hello {world}")'
-        expected = 'log.debug("hello %s", world)'
+        source = "log.debug(f'hello {world}')"
+        expected = "log.debug('hello %s', world)"
         self.assert_patched(source, expected)
 
     def test_fstring_with_no_substitutions(self):
-        source = 'log.debug(f"hello world")'
-        expected = 'log.debug("hello world")'
+        source = "log.debug(f'hello world')"
+        expected = "log.debug('hello world')"
         self.assert_patched(source, expected)
 
     def test_fstring_formatted_value_f(self):
-        source = 'log.debug(f"pi is {pi:2.3f}")'
-        expected = 'log.debug("pi is %2.3f", pi)'
+        source = "log.debug(f'pi is {pi:2.3f}')"
+        expected = "log.debug('pi is %2.3f', pi)"
         self.assert_patched(source, expected)
 
     def test_fstring_formatted_value_d(self):
-        source = 'log.debug(f"x is {x:03d}")'
-        expected = 'log.debug("x is %03d", x)'
+        source = "log.debug(f'x is {x:03d}')"
+        expected = "log.debug('x is %03d', x)"
         self.assert_patched(source, expected)
 
     def test_fstring_formatted_value_s(self):
-        source = 'log.debug(f"hello {world:20}")'
-        expected = 'log.debug("hello %20s", world)'
+        source = "log.debug(f'hello {world:20}')"
+        expected = "log.debug('hello %20s', world)"
         self.assert_patched(source, expected)
 
     def test_fstring_formatted_value_s_left(self):
-        source = 'log.debug(f"hello {world:<20}")'
-        expected = 'log.debug("hello %-20s", world)'
+        source = "log.debug(f'hello {world:<20}')"
+        expected = "log.debug('hello %-20s', world)"
         self.assert_patched(source, expected)
 
     def test_fstring_formatted_value_s_right(self):
-        source = 'log.debug(f"hello {world:>20}")'
-        expected = 'log.debug("hello %20s", world)'
+        source = "log.debug(f'hello {world:>20}')"
+        expected = "log.debug('hello %20s', world)"
         self.assert_patched(source, expected)
 
 
 class PatchIgnoreLazyTest(PatchTestBase):
     """Logging statements that should not be patched"""
+
     def test_ignore_lazy_1(self):
-        source = 'log.debug("%s", a)'
+        source = "log.debug('%s', a)"
         self.assert_unchanged(source)
 
     def test_ignore_lazy_3(self):
-        source = 'log.debug("%s %s %s", a, b, c)'
+        source = "log.debug('%s %s %s', a, b, c)"
         self.assert_unchanged(source)
 
 
 class PatchStrFormatTest(PatchTestBase):
     """Test patching statements that use ``str.format`` for formatting."""
+
     def test_preserve_format_string_strformat(self):
-        source = 'log.info("%s %d %f".format(a, b, c))'
-        expected = 'log.info("%s %d %f", a, b, c)'
+        source = "log.info('%s %d %f'.format(a, b, c))"
+        expected = "log.info('%s %d %f', a, b, c)"
         self.assert_patched(source, expected)
 
     def test_str_format_curly_braces_3(self):
-        source = 'log.debug("{} {} {}".format(a, b, c))'
-        expected = 'log.debug("%s %s %s", a, b, c)'
+        source = "log.debug('{} {} {}'.format(a, b, c))"
+        expected = "log.debug('%s %s %s', a, b, c)"
         self.assert_patched(source, expected)
 
     def test_ignore_str_format_with_variable(self):
@@ -148,28 +150,28 @@ class PatchStrFormatTest(PatchTestBase):
         self.assert_unchanged(source)
 
     def test_ignore_str_format_with_keywords(self):
-        source = 'log.debug("hello {world}".format(world="world"))'
+        source = "log.debug('hello {world}'.format(world='world'))"
         self.assert_unchanged(source)
 
     def test_ignore_str_format_formatted_value(self):
-        source = 'log.debug("{:.2f} {:^20}".format(3.1456, world))'
+        source = "log.debug('{:.2f} {:^20}'.format(3.1456, world))"
         self.assert_unchanged(source)
 
     def test_ignore_str_format_formatted_float_value(self):
-        source = 'log.debug("{:.2f}".format(3.1456))'
+        source = "log.debug('{:.2f}'.format(3.1456))"
         self.assert_unchanged(source)
 
     def test_ignore_str_format_formatted_s_value(self):
-        source = 'log.debug("{:20}".format(world))'
+        source = "log.debug('{:20}'.format(world))"
         self.assert_unchanged(source)
 
     def test_ignore_str_format_formatted_positionals(self):
-        source = 'log.debug("hello {0}".format(world))'
+        source = "log.debug('hello {0}'.format(world))"
         self.assert_unchanged(source)
 
     # def test_str_format_3_functions(self):
-    #     source = 'log.debug("%d %f %s".format(a+b, log(a), foo(bar(x,y))))'
-    #     expected = 'log.debug("%d %f %s", a + b, log(a), foo(bar(x, y)))'
+    #     source = "log.debug('%d %f %s".format(a+b, log(a), foo(bar(x,y))))"
+    #     expected = "log.debug('%d %f %s", a + b, log(a), foo(bar(x, y)))"
     #     self.assert_patched(source, expected)
 
 


### PR DESCRIPTION
Massage the AST to create a new logging statement rather that trying to format a string.